### PR TITLE
feat: pass keg to +brew-link-keg

### DIFF
--- a/zsh/.config/zsh/functions/+brew-link-keg
+++ b/zsh/.config/zsh/functions/+brew-link-keg
@@ -1,41 +1,59 @@
 #autoload
 # vim: set et:ft=zsh:sw=2:st=2:ts=2:tw=100:
+#
+# brew-link-keg
+#
 
-emulate -L zsh
-setopt EXTENDED_GLOB
-
-zmodload zsh/zutil || return 1
-
-opt_help=
-cli_usage=("Usage: +brew-link-kegs [-h|--help]")
-zparseopts -D -F -K -- {h,-help}=opt_help || return 1
-[[ -z "$opt_help" ]] || {
-    builtin print -l $cli_usage && return
-}
-
-brew_keg_only=($(brew info --installed --json=v1 | jq --raw-output --compact-output  'map(select(.keg_only == true)) | map(.name) | @sh'))
-if (( ${#brew_keg_only} > 0 )); then
-    local HOMEBREW_PREFIX="$(brew --prefix)"
-    for keg in ${(@on)brew_keg_only}; do
-        PATH="${HOMEBREW_PREFIX}/opt/${(Q)keg}/bin:${PATH}"
-        builtin print -P -- "%F{green}==>%f [+] ${(Q)keg}"
-    done
-fi
-
-local f_path util
-local -a gnu_paths=(/opt/homebrew/opt /usr/local/opt)
-for f_path in $gnu_paths; do
-    if [[ -e $f_path ]]; then
-        builtin print -P -- "%F{cyan}==>%f searching ${(Q)f_path}"
-        local -a gnu_tools=($(find $f_path -follow -type d -path '*gnubin*' -print))
-        if (( ${#gnu_tools} > 0 )); then
-            for util in ${(@on)gnu_tools}; do
-                PATH="${(Q)util}:${PATH}"
-                util_name="$(print -n -- ${util}/*(:t))"
-                builtin print -P -- "%F{green}==>%f [+] ${(Q)util_name}"
-            done
-        fi
++brew-link-keg () {
+    __brew-link-keg_usage () {
+        print -- 'Usage: brew-link-keg [options] [arguments...]'
+        print -- 'Options:'
+        print -- '  -a, --all          add all unlinked kegs found'
+        print -- '  -d, --debug        turn on execution tracing'
+        print -- '  -h, --help         show list of command-line options'
+    }
+    setopt localoptions extended_glob
+    zmodload zsh/zutil || return 1
+    local all base debug dryrun help
+    builtin zparseopts -D -E -F -K a=all -all=all d=debug -debug=debug h=help -help=help || return 1
+    if (( $#help )); then
+        __brew-link-keg_usage
+        return 0
     fi
-done
-
-typeset -Ugx PATH
+    if (( $#debug )); then
+        setopt xtrace
+    fi
+    local -a arguments=(${(q+)^@}) 
+    if (( $#all )); then
+        arguments=('(*)') 
+    fi
+    print -- "${#arguments} args: ${(@pj:, :)arguments}"
+    brew_keg_only=($(brew info --installed --json=v1 | jq --raw-output --compact-output  'map(select(.keg_only == true)) | map(.name) | @sh')) 
+    if (( ${#brew_keg_only} > 0 )); then
+        local HOMEBREW_PREFIX="$(brew --prefix)" 
+        local -a subarray
+        subarray=(${(M)brew_keg_only:#*${~1:-${~arguments[@]}}*}) 
+        for keg in ${(@on)subarray}; do
+            PATH="${HOMEBREW_PREFIX}/opt/${(Q)keg}/bin:${PATH}" 
+            builtin print -P -- "%F{green}==>%f [+] ${(Q)keg}"
+        done
+    fi
+    local f_path util
+    local -a gnu_paths=(/opt/homebrew/opt /usr/local/opt) 
+    for f_path in $gnu_paths; do
+        if [[ -e $f_path ]]; then
+            local -a gnu_tools=($(find $f_path -follow -type d -path '*gnubin*' -print)) 
+            if (( ${#gnu_tools} > 0 )); then
+                builtin print -P -- "%F{cyan}==>%f found utils in ${(Q)f_path}"
+                local -a subarray=() 
+                subarray=(${(M)gnu_tools:#*${~1:-${~arguments[@]}}*}) 
+                for util in ${(@on)subarray}; do
+                    PATH="${(Q)util}:${PATH}" 
+                    util_name="$(print -n -- ${util}/*(:t))" 
+                    builtin print -P -- "%F{green}==>%f [+] ${(Q)util_name}"
+                done
+            fi
+        fi
+    done
+    typeset -Ugx PATH
+}


### PR DESCRIPTION
Ability to add individual keg to `$PATH`

## Usage examples

```console
$ +brew-link-keg ncurses
1 args: ncurses
==> [+] ncurses
==> found utils in /opt/homebrew/opt
```

## Types of changes

- [ ] Breaking change
- [ ] Bug fix
- [ ] Documentation
- [X] New feature
