### PR TITLE
fix(zsh): set default `ZDOTDIR` in .zshenv

### DIFF
--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -1,4 +1,6 @@
 #!/usr/bin/env zsh
 # vim: set ft=zsh:et:sts=2:sw=2:ts=2:tw=100:
 
-ZDOTDIR=$HOME/.config/zsh
+: ${ZDOTDIR:=$HOME/.config/zsh}
+
+setopt rcs


### PR DESCRIPTION
* Changed the assignment of `ZDOTDIR` to use the `:${VAR:=value}` idiom, which only sets the variable if it is unset, improving robustness.
* Added `setopt rcs` to ensure that `.zshrc` is loaded from the directory specified by `ZDOTDIR`.